### PR TITLE
Navbar desplegable en sm devices, Pag. Sobre Nosotros

### DIFF
--- a/pages/quienesSomos.html
+++ b/pages/quienesSomos.html
@@ -205,4 +205,9 @@
             </div>
         </footer>
     </body>
+    <script
+        src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"
+        crossorigin="anonymous"
+    ></script>
 </html>


### PR DESCRIPTION
Arreglé que no se desplegaba el botón hamburguesa en dispositivos small, porque no estaba linkeado el script js de bootstrap